### PR TITLE
confine pre-commit to stages

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,7 @@
   name: black
   description: "Black: The uncompromising Python code formatter"
   entry: black
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
   language: python
   minimum_pre_commit_version: 2.9.2
   require_serial: true
@@ -11,6 +12,7 @@
   description:
     "Black: The uncompromising Python code formatter (with Jupyter Notebook support)"
   entry: black
+  stages: [pre-commit, pre-merge-commit, pre-push, manual]
   language: python
   minimum_pre_commit_version: 2.9.2
   require_serial: true


### PR DESCRIPTION
Originally done upstream in https://github.com/psf/black/pull/3940


See https://pre-commit.com/#confining-hooks-to-run-at-certain-stages

> If you are authoring a tool, it is usually a good idea to provide an appropriate `stages` property. For example a reasonable setting for a linter or code formatter would be `stages: [pre-commit, pre-merge-commit, pre-push, manual]`.